### PR TITLE
feat #6 @KafkaListener로 Consumer 생성

### DIFF
--- a/src/main/java/com/example/kafkatest/MyConsumer.java
+++ b/src/main/java/com/example/kafkatest/MyConsumer.java
@@ -7,17 +7,24 @@ import org.springframework.stereotype.Component;
 public class MyConsumer {
 
     // kafka Consumer 생성하기
+
+    /**
+     * localhost가 아니라 특정 port를 사용하기 위해서는
+     * -> KafkaMessageListenerContainer가 아니라
+     * -> ConcurrentKafkaListenerContainerFactory를 사용해야 한다.
+     */
     @KafkaListener(
             id = "mygroup5",// consumer  그룹 아이디
-            topics = "mytest3"// topic
+            topics = "mytest3",// topic
+            containerFactory = "concurrentMessageListenerContainer"
     )
     public void listen(String message) {
 
-        System.out.println("================= mytest3 topic의 partition에 있는 데이터 시작 ================");
+        System.out.println("================= 1111111 mytest3 topic의 partition에 있는 데이터 시작 ================");
 
         System.out.println(message);
 
-        System.out.println("================= mytest3 topic의 partition에 있는 데이터 끝 ================");
+        System.out.println("================= 1111111 mytest3 topic의 partition에 있는 데이터 끝 ================");
 
 
     }

--- a/src/main/java/com/example/kafkatest/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/example/kafkatest/config/KafkaConsumerConfig.java
@@ -7,8 +7,10 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
 import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.listener.KafkaMessageListenerContainer;
 
@@ -19,10 +21,27 @@ import java.util.Map;
 public class KafkaConsumerConfig {
 
     /**
+     * 기능 : ConcurrentKafkaListenerContainerFactory 사용
+     * comment : -> @KafkaListener 상용하기 위해서
+     */
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> concurrentMessageListenerContainer() {
+
+        ConcurrentKafkaListenerContainerFactory<String, String> concurrentFactory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+
+        // consumerFactory를 주입한다.
+        concurrentFactory.setConsumerFactory(consumerFactory());
+
+        return concurrentFactory;
+    }
+
+    /**
      * 기능 : Consumer 객체를 생성하기
      *       => Consumer 객체에서 왜 속성을 다시 정의하나요?
      *       => props에서 하지 않는 이유는 무엇인가요?
      *          => 서로 다른 용도의 Consumer가 있기 때문에?
+     * comment : interface인 MessageListener를 사용해서 컨슈머를 등록한다.
      */
     @Bean
     public KafkaMessageListenerContainer<String, String> makeListenerContainer() {


### PR DESCRIPTION
### 변경사항
- localhost:9092가 아닌 특정 port로 Consumer의 Listener를 생성하려면 ConcurrentKafkaListenerContainerFactory 객체를 생성해야 한다.